### PR TITLE
add all orders adjustments

### DIFF
--- a/app/models/mercado_pago/order_preferences_builder.rb
+++ b/app/models/mercado_pago/order_preferences_builder.rb
@@ -53,7 +53,7 @@ module MercadoPago
     end
 
     def generate_items_from_adjustments
-      @order.adjustments.eligible.collect do |adjustment|
+      @order.all_adjustments.eligible.collect do |adjustment|
         {
           title: line_item_description_text(adjustment.label),
           unit_price: adjustment.amount.to_f,


### PR DESCRIPTION
## Description
This method wasn't taking into account if exist promotions by line item only by order so the incorrect amount was sent to Mercado Pago.