### PR TITLE
Store Credentials in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,32 @@ bundle exec rails g solidus_mercado_pago:install
 
 This will import assets and migrations
 
-Configuration
+Basic Setup
 -----
-*config/secrets.yml*
 
-```
-development:
-  secret_key_base: ...
-  mercadopago:
-    client_id: <client id from mercadopago>
-    client_secret: <client secret from mercadopago>
-    sandbox: true | false
-```
+## Retrieve Mercado pago account details
+You'll need the following account details:
+
+- Client ID
+- Client secret
+- Sandbox (A boolean value to indicate if we're using the sandbox or not)
+
+These values can be obtained by logging in to your Mercado Pago account, going to `Credentials -> Basic checkout`
+
+## Create a new payment method
+
+Payment methods can accept preferences either directly entered in admin.
+
+1. Visit `/admin/payment_methods/new`
+2. Set `Mercado pago` as provider.
+3. Save to update the form
+4. Set your credentials into the corresponding fields
+
+By default, your preferences can be gained from your environment vars (`MERCADOPAGO_CLIENT_ID`, `MERCADOPAGO_CLIENT_SECRET`), except by `sandbox`; its default value is `true`.
+
+
+Other option is create the payment method from admin interface:
+
 
 Usage
 -----

--- a/app/models/mercado_pago/client/api.rb
+++ b/app/models/mercado_pago/client/api.rb
@@ -30,7 +30,7 @@ class MercadoPago::Client
     end
 
     def sandbox
-      Rails.application.try(:secrets).try(:[], :mercadopago).try(:[], :sandbox)
+      @payment_method.preferred_sandbox
     end
 
     def get(url, request_options = {}, options = {})

--- a/app/models/mercado_pago/client/authentication.rb
+++ b/app/models/mercado_pago/client/authentication.rb
@@ -21,11 +21,11 @@ class MercadoPago::Client
     end
 
     def client_id
-      Rails.application.try(:secrets).try(:[], :mercadopago).try(:[], :client_id)
+      @payment_method.preferred_client_id
     end
 
     def client_secret
-      Rails.application.try(:secrets).try(:[], :mercadopago).try(:[], :client_secret)
+      @payment_method.preferred_client_secret
     end
 
     def access_token

--- a/app/models/spree/payment_method/mercado_pago.rb
+++ b/app/models/spree/payment_method/mercado_pago.rb
@@ -1,5 +1,10 @@
 module Spree
   class PaymentMethod::MercadoPago < PaymentMethod
+
+    preference :sandbox, :boolean, default: true
+    preference :client_id, :string, default: ENV['MERCADOPAGO_CLIENT_ID']
+    preference :client_secret, :string, default: ENV['MERCADOPAGO_CLIENT_SECRET']
+
     def payment_profiles_supported?
       false
     end
@@ -23,10 +28,6 @@ module Spree
 
     def auto_capture?
       false
-    end
-
-    def preferred_sandbox
-      Rails.application.try(:secrets).try(:[], :mercadopago).try(:[], :sandbox)
     end
 
     ## Admin options

--- a/spec/models/mercado_pago/client_spec.rb
+++ b/spec/models/mercado_pago/client_spec.rb
@@ -134,4 +134,36 @@ RSpec.describe MercadoPago::Client, type: :model do
       end
     end
   end
+
+  context 'payment method with preferences' do
+    let(:preferences) do
+      {
+        client_id: '6nVDZ8MsMS',
+        client_secret: 'o5ODEtNt6h',
+        sandbox: false
+      }
+    end
+
+    let(:payment_method) { Spree::PaymentMethod::MercadoPago.new(preferences: preferences) }
+
+    let(:mercado_pago) { described_class.new(payment_method) }
+
+    describe '#client_id' do
+      it 'comes from payment method' do
+        expect(mercado_pago.send(:client_id)).to eq payment_method.preferred_client_id
+      end
+    end
+
+    describe '#client_secret' do
+      it 'comes from payment method' do
+        expect(mercado_pago.send(:client_secret)).to eq payment_method.preferred_client_secret
+      end
+    end
+
+    describe '#sandbox' do
+      it 'comes from payment method' do
+        expect(mercado_pago.send(:sandbox)).to eq payment_method.preferred_sandbox
+      end
+    end
+  end
 end

--- a/spec/models/spree/payment_method/mercado_pago_spec.rb
+++ b/spec/models/spree/payment_method/mercado_pago_spec.rb
@@ -12,13 +12,10 @@ RSpec.describe Spree::PaymentMethod::MercadoPago do
     it { expect(payment_method.auto_capture?).to eq false }
 
     describe 'sandbox' do
-      it 'true' do
-        Rails.application.secrets.mercadopago = { sandbox: true }
+      let(:preferences) { { sandbox: true } }
+      let(:payment_method) { described_class.new(preferences: preferences) }
+      it 'stores sandbox value as model preference' do
         expect(payment_method.preferred_sandbox).to eq true
-      end
-      it 'false' do
-        Rails.application.secrets.mercadopago = { sandbox: false }
-        expect(payment_method.preferred_sandbox).to eq false
       end
     end
 


### PR DESCRIPTION
## Quick Info

Migrations? 👍 

## What does this change?
This changes the way to manage the mercado pago credentials. This adds the option to store these into database. Also mantain the option to use ENV vars, but in a different way (creating static model preferences)
