### PR TITLE
Remove dependency

### DIFF
--- a/lib/solidus_mercado_pago/version.rb
+++ b/lib/solidus_mercado_pago/version.rb
@@ -1,3 +1,3 @@
 module SolidusMercadoPago
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/solidus_mercado_pago.gemspec
+++ b/solidus_mercado_pago.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', '~> 2.4'
   s.add_dependency 'solidus_support', '~> 0'
 
-  s.add_dependency 'bootstrap-sass',  '>= 3.3.5.1', '< 3.4'
   s.add_dependency 'canonical-rails', '~> 0.2.0'
   s.add_dependency 'jquery-rails',    '~> 4.1'
 


### PR DESCRIPTION
Description
-
We want to remove `bootstrap-sass` dependency because we don't need it.